### PR TITLE
Missing ">" in script tag

### DIFF
--- a/timify-widget.php
+++ b/timify-widget.php
@@ -76,7 +76,7 @@ class TimifyWidget {
 				<?php } ?>
 				data-locale="<?php echo $this->timifyWidgetLanguage; ?>"
 				type="text/javascript"
-				data-position="<?php echo ($this->timifyWidgetPosition != 'left' && $this->timifyWidgetPosition != 'right' ? 'multiple' : $this->timifyWidgetPosition); ?>"
+				data-position="<?php echo ($this->timifyWidgetPosition != 'left' && $this->timifyWidgetPosition != 'right' ? 'multiple' : $this->timifyWidgetPosition); ?>">
 			</script>
 		<?php	}
 	}


### PR DESCRIPTION
There is a missing closing tag ">" in "addToFooter" function 

When plugin is loaded before other plugins, that will break these other plugins.